### PR TITLE
fix: php warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-MultiFaucet v0.8.5
+MultiFaucet v0.8.6
 ==================
 Copyright 2014 by The Daniel Morante Company, Inc.
 http://www.unibia.net/crypto-faucet

--- a/includes/lang.inc.php
+++ b/includes/lang.inc.php
@@ -1,5 +1,5 @@
 <?php
-$lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
+$lang = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2) : '';
 
 //FB::log("Detected Language: " . $lang);
 

--- a/libraries/simple-captcha/simple-php-captcha.php
+++ b/libraries/simple-captcha/simple-php-captcha.php
@@ -65,7 +65,7 @@ function simple_php_captcha($config = array()) {
 	if( $captcha_config['max_font_size'] < $captcha_config['min_font_size'] ) $captcha_config['max_font_size'] = $captcha_config['min_font_size'];
 	
 	// Use milliseconds instead of seconds
-	srand(microtime() * 100);
+	srand(microtime(1) * 100);
 	
 	// Generate CAPTCHA code if not set by user
 	if( empty($captcha_config['code']) ) {
@@ -132,7 +132,7 @@ if( isset($_GET['_CAPTCHA']) ) {
 	unset($_SESSION['_CAPTCHA']);
 	
 	// Use milliseconds instead of seconds
-	srand(microtime() * 100);
+	srand(microtime(1) * 100);
 	
 	// Pick random background, get info, and start captcha
 	$background = $captcha_config['backgrounds'][rand(0, count($captcha_config['backgrounds']) -1)];

--- a/system/app.conf.php
+++ b/system/app.conf.php
@@ -1,6 +1,6 @@
 <?php
 define('APPLICATION_NAME', 'MultiFaucet');
 define('APPLICATION_WEBSITE', 'http://www.unibia.net/crypto-faucet');
-define('APPLICATION_VERSION', 'Beta v. 0.8.3');
+define('APPLICATION_VERSION', '0.8.6');
 define('APPLICATION_CONFDIR', (@$MULTISITE_CONFDIR ?: 'config/')); //Must have trailing '/'
 ?>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Logs are full of this sort of thing:
```
[Wed Nov 23 05:07:09.052105 2022] [php:warn] [pid 2447] [client 10.0.29.91:7326] PHP Warning:  Undefined array key "HTTP_ACCEPT_LANGUAGE" in /var/www/html/includes/lang.inc.php on line 2
[Wed Nov 23 05:07:09.143899 2022] [php:warn] [pid 2447] [client 10.0.29.91:7326] PHP Warning:  A non-numeric value encountered in /var/www/html/libraries/simple-captcha/simple-php-captcha.php on line 68
```

## What was done?
<!--- Describe your changes in detail -->
Trivial PHP changes to hide warnings.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
